### PR TITLE
Basic e2e integration test for the p2p stuff inside deqs-server

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1155,6 +1155,7 @@ dependencies = [
  "futures",
  "grpcio",
  "lazy_static",
+ "mc-account-keys",
  "mc-api",
  "mc-common",
  "mc-ledger-db",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1171,6 +1171,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tokio",
+ "tokio-retry",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5756,6 +5756,7 @@ dependencies = [
  "mio",
  "num_cpus",
  "pin-project-lite 0.2.9",
+ "signal-hook-registry",
  "socket2",
  "tokio-macros",
  "windows-sys",

--- a/p2p/src/network_event_loop.rs
+++ b/p2p/src/network_event_loop.rs
@@ -364,7 +364,13 @@ impl<REQ: RpcRequest, RESP: RpcResponse> NetworkEventLoop<REQ, RESP> {
             }
 
             Command::ListenAddrList { response_sender } => {
-                let listen_addrs = self.swarm.listeners().cloned().collect();
+                let mut listen_addrs = self.swarm.listeners().cloned().collect::<Vec<_>>();
+
+                // Add our peer id to each listen address. This makes the address usable by
+                // clients.
+                for listen_addr in listen_addrs.iter_mut() {
+                    listen_addr.push(Protocol::P2p(self.swarm.local_peer_id().clone().into()));
+                }
 
                 response_sender
                     .send(listen_addrs)

--- a/p2p/src/network_event_loop.rs
+++ b/p2p/src/network_event_loop.rs
@@ -369,7 +369,7 @@ impl<REQ: RpcRequest, RESP: RpcResponse> NetworkEventLoop<REQ, RESP> {
                 // Add our peer id to each listen address. This makes the address usable by
                 // clients.
                 for listen_addr in listen_addrs.iter_mut() {
-                    listen_addr.push(Protocol::P2p(self.swarm.local_peer_id().clone().into()));
+                    listen_addr.push(Protocol::P2p((*self.swarm.local_peer_id()).into()));
                 }
 
                 response_sender

--- a/quote-book/Cargo.toml
+++ b/quote-book/Cargo.toml
@@ -12,7 +12,7 @@ serde = { version = "1.0", default-features = false, features = ["alloc", "deriv
 mc-blockchain-types = { path = "../mobilecoin/blockchain/types" }
 mc-crypto-digestible = { path = "../mobilecoin/crypto/digestible" }
 mc-crypto-ring-signature = { path = "../mobilecoin/crypto/ring-signature" }
-mc-ledger-db = { path = "../mobilecoin/ledger/db", features = ["test_utils"] }
+mc-ledger-db = { path = "../mobilecoin/ledger/db" }
 mc-transaction-core = { path = "../mobilecoin/transaction/core" }
 mc-transaction-extra = { path = "../mobilecoin/transaction/extra" }
 mc-transaction-types = { path = "../mobilecoin/transaction/types" }
@@ -29,4 +29,5 @@ mc-account-keys = { path = "../mobilecoin/account-keys" }
 mc-blockchain-test-utils = { path = "../mobilecoin/blockchain/test-utils" }
 mc-crypto-ring-signature-signer = { path = "../mobilecoin/crypto/ring-signature/signer", default-features = false }
 mc-fog-report-validation-test-utils = { path = "../mobilecoin/fog/report/validation/test-utils" }
+mc-ledger-db = { path = "../mobilecoin/ledger/db", features = ["test_utils"] }
 mc-transaction-builder = { path = "../mobilecoin/transaction/builder", features = ["test-only"] }

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -40,6 +40,8 @@ tokio = { version = "1.0", features = ["rt", "rt-multi-thread", "macros", "time"
 [dev-dependencies]
 deqs-mc-test-utils = { path = "../mc-test-utils" }
 
+mc-account-keys = { path = "../mobilecoin/account-keys" }
+mc-ledger-db = { path = "../mobilecoin/ledger/db", features = ["test_utils"] }
 mc-transaction-types = { path = "../mobilecoin/transaction/types" }
 
 rand = "0.8"

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -45,3 +45,4 @@ mc-ledger-db = { path = "../mobilecoin/ledger/db", features = ["test_utils"] }
 mc-transaction-types = { path = "../mobilecoin/transaction/types" }
 
 rand = "0.8"
+tokio-retry = "0.3"

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -35,7 +35,7 @@ postage = "0.5"
 rayon = "1.6"
 serde = { version = "1.0", default-features = false, features = ["alloc", "derive"] }
 serde_json = "1.0"
-tokio = { version = "1.0", features = ["rt", "rt-multi-thread", "macros", "time", "sync"] }
+tokio = { version = "1.0", features = ["rt", "rt-multi-thread", "macros", "time", "signal", "sync"] }
 
 [dev-dependencies]
 deqs-mc-test-utils = { path = "../mc-test-utils" }

--- a/server/src/bin/main.rs
+++ b/server/src/bin/main.rs
@@ -3,7 +3,7 @@
 use clap::Parser;
 use deqs_p2p::libp2p::identity::Keypair;
 use deqs_quote_book::{InMemoryQuoteBook, SynchronizedQuoteBook};
-use deqs_server::{Msg, Server, ServerConfig, P2P};
+use deqs_server::{GrpcServer, Msg, ServerConfig, P2P};
 use mc_common::logger::{log, o};
 use mc_ledger_db::{Ledger, LedgerDB};
 use mc_util_grpc::AdminServer;
@@ -53,13 +53,15 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     .await?;
 
     // Start GRPC server
-    let mut server = Server::new(
+    let mut grpc_server = GrpcServer::new(
         msg_bus_tx,
         synchronized_quote_book,
         config.client_listen_uri.clone(),
         logger.clone(),
     );
-    server.start().expect("Failed starting client GRPC server");
+    grpc_server
+        .start()
+        .expect("Failed starting client GRPC server");
 
     // Start admin server
     let config_json = serde_json::to_string(&config).expect("failed to serialize config to JSON");

--- a/server/src/bin/main.rs
+++ b/server/src/bin/main.rs
@@ -3,16 +3,11 @@
 use clap::Parser;
 use deqs_p2p::libp2p::identity::Keypair;
 use deqs_quote_book::{InMemoryQuoteBook, SynchronizedQuoteBook};
-use deqs_server::{GrpcServer, Msg, ServerConfig, P2P};
+use deqs_server::{DeqsServer, ServerConfig};
 use mc_common::logger::{log, o};
 use mc_ledger_db::{Ledger, LedgerDB};
 use mc_util_grpc::AdminServer;
-use postage::{broadcast, prelude::Stream};
 use std::sync::Arc;
-use tokio::select;
-
-/// Maximum number of messages that can be queued in the message bus.
-const MSG_BUS_QUEUE_SIZE: usize = 1000;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -21,8 +16,6 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let (logger, _global_logger_guard) = mc_common::logger::create_app_logger(o!());
     mc_common::setup_panic_handler();
 
-    let (msg_bus_tx, mut msg_bus_rx) = broadcast::channel::<Msg>(MSG_BUS_QUEUE_SIZE);
-
     // Open the ledger db
     let ledger_db = LedgerDB::open(&config.ledger_db).expect("Could not open ledger db");
     let num_blocks = ledger_db
@@ -30,38 +23,19 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .expect("Could not compute num_blocks");
     assert_ne!(0, num_blocks);
 
+    // Read keypair, if provided.
+    let keypair = config
+        .p2p_keypair_path
+        .as_ref()
+        .map(|path| -> Result<Keypair, Box<dyn std::error::Error>> {
+            let bytes = std::fs::read(path)?;
+            Ok(Keypair::from_protobuf_encoding(&bytes)?)
+        })
+        .transpose()?;
+
     // Create quote book
     let internal_quote_book = InMemoryQuoteBook::default();
     let synchronized_quote_book = SynchronizedQuoteBook::new(internal_quote_book, ledger_db);
-
-    // Init p2p network
-    let (mut p2p, mut p2p_events) = P2P::new(
-        synchronized_quote_book.clone(),
-        config.p2p_bootstrap_peers.clone(),
-        config.p2p_listen.clone(),
-        config.p2p_external_address.clone(),
-        config
-            .p2p_keypair_path
-            .as_ref()
-            .map(|path| -> Result<Keypair, Box<dyn std::error::Error>> {
-                let bytes = std::fs::read(path)?;
-                Ok(Keypair::from_protobuf_encoding(&bytes)?)
-            })
-            .transpose()?,
-        logger.clone(),
-    )
-    .await?;
-
-    // Start GRPC server
-    let mut grpc_server = GrpcServer::new(
-        msg_bus_tx,
-        synchronized_quote_book,
-        config.client_listen_uri.clone(),
-        logger.clone(),
-    );
-    grpc_server
-        .start()
-        .expect("Failed starting client GRPC server");
 
     // Start admin server
     let config_json = serde_json::to_string(&config).expect("failed to serialize config to JSON");
@@ -79,41 +53,20 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .expect("Failed starting admin server")
     });
 
-    // Event loop
-    loop {
-        select! {
-            msg = msg_bus_rx.recv() => {
-                match msg {
-                    Some(Msg::SciQuoteAdded(quote)) => {
-                        if let Err(err) = p2p.broadcast_sci_quote_added(quote).await {
-                            log::info!(logger, "broadcast_sci_quote_added failed: {:?}", err)
-                        }
-                    }
+    // Start deqs server. Stays alive as long as it remains in scope.
+    let _deqs_server = DeqsServer::start(
+        synchronized_quote_book,
+        config.client_listen_uri,
+        config.p2p_bootstrap_peers,
+        config.p2p_listen,
+        config.p2p_external_address,
+        keypair,
+        logger.clone(),
+    )
+    .await?;
 
-                    Some(Msg::SciQuoteRemoved(quote_id)) => {
-                        if let Err(err) = p2p.broadcast_sci_quote_removed(quote_id).await {
-                            log::info!(logger, "broadcast_sci_quote_removed failed: {:?}", err)
-                        }
-                    }
-
-                    None => {
-                            log::info!(logger, "msg_bus_rx stream closed");
-                            break;
-                    }
-                }
-            }
-
-            event = p2p_events.recv() => {
-                match event {
-                    Some(event) => p2p.handle_network_event(event).await,
-                    None => {
-                        log::info!(logger, "p2p_events stream closed");
-                        break;
-                    }
-                }
-            }
-        }
-    }
+    // Wait until we are asked to quit.
+    tokio::signal::ctrl_c().await?;
 
     Ok(())
 }

--- a/server/src/bin/main.rs
+++ b/server/src/bin/main.rs
@@ -3,8 +3,8 @@
 use clap::Parser;
 use deqs_p2p::libp2p::identity::Keypair;
 use deqs_quote_book::{InMemoryQuoteBook, SynchronizedQuoteBook};
-use deqs_server::{DeqsServer, ServerConfig};
-use mc_common::logger::{log, o};
+use deqs_server::{Server, ServerConfig};
+use mc_common::logger::o;
 use mc_ledger_db::{Ledger, LedgerDB};
 use mc_util_grpc::AdminServer;
 use std::sync::Arc;
@@ -54,7 +54,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     });
 
     // Start deqs server. Stays alive as long as it remains in scope.
-    let _deqs_server = DeqsServer::start(
+    let _deqs_server = Server::start(
         synchronized_quote_book,
         config.client_listen_uri,
         config.p2p_bootstrap_peers,

--- a/server/src/deqs_server.rs
+++ b/server/src/deqs_server.rs
@@ -1,0 +1,127 @@
+// Copyright (c) 2023 MobileCoin Inc.
+
+use crate::{Error, GrpcServer, Msg, P2P};
+use deqs_api::DeqsClientUri;
+use deqs_p2p::libp2p::{identity::Keypair, Multiaddr};
+use deqs_quote_book::QuoteBook;
+use mc_common::logger::{log, Logger};
+use postage::{broadcast, prelude::Stream};
+use tokio::{select, sync::mpsc};
+
+/// Maximum number of messages that can be queued in the message bus.
+const MSG_BUS_QUEUE_SIZE: usize = 1000;
+
+pub struct DeqsServer<QB: QuoteBook> {
+    /// Shutdown sender, used to signal the event loop to shutdown.
+    shutdown_tx: mpsc::UnboundedSender<()>,
+
+    /// Shutdown acknowledged receiver.
+    shutdown_ack_rx: mpsc::UnboundedReceiver<()>,
+
+    /// Must hold a reference to the grpc server, otherwise it will be dropped.
+    grpc_server: GrpcServer<QB>,
+}
+
+impl<QB: QuoteBook> DeqsServer<QB> {
+    pub async fn start(
+        quote_book: QB,
+        grpc_listen_address: DeqsClientUri,
+        p2p_bootstrap_peers: Vec<Multiaddr>,
+        p2p_listen_address: Option<Multiaddr>,
+        p2p_external_address: Option<Multiaddr>,
+        p2p_keypair: Option<Keypair>,
+        logger: Logger,
+    ) -> Result<Self, Error> {
+        let (msg_bus_tx, mut msg_bus_rx) = broadcast::channel::<Msg>(MSG_BUS_QUEUE_SIZE);
+        let (shutdown_tx, mut shutdown_rx) = mpsc::unbounded_channel();
+        let (shutdown_ack_tx, shutdown_ack_rx) = mpsc::unbounded_channel();
+
+        // Init p2p network
+        let (mut p2p, mut p2p_events) = P2P::new(
+            quote_book.clone(),
+            p2p_bootstrap_peers,
+            p2p_listen_address,
+            p2p_external_address,
+            p2p_keypair,
+            logger.clone(),
+        )
+        .await?;
+
+        // Start GRPC server
+        let mut grpc_server =
+            GrpcServer::new(msg_bus_tx, quote_book, grpc_listen_address, logger.clone());
+        grpc_server
+            .start()
+            .expect("Failed starting client GRPC server");
+
+        // Event loop
+        tokio::spawn(async move {
+            log::info!(logger, "DeqsServer event loop started");
+
+            loop {
+                select! {
+                    msg = msg_bus_rx.recv() => {
+                        match msg {
+                            Some(Msg::SciQuoteAdded(quote)) => {
+                                if let Err(err) = p2p.broadcast_sci_quote_added(quote).await {
+                                    log::info!(logger, "broadcast_sci_quote_added failed: {:?}", err)
+                                }
+                            }
+
+                            Some(Msg::SciQuoteRemoved(quote_id)) => {
+                                if let Err(err) = p2p.broadcast_sci_quote_removed(quote_id).await {
+                                    log::info!(logger, "broadcast_sci_quote_removed failed: {:?}", err)
+                                }
+                            }
+
+                            None => {
+                                    log::info!(logger, "msg_bus_rx stream closed");
+                                    break;
+                            }
+                        }
+                    }
+
+                    event = p2p_events.recv() => {
+                        match event {
+                            Some(event) => p2p.handle_network_event(event).await,
+                            None => {
+                                log::info!(logger, "p2p_events stream closed");
+                                break;
+                            }
+                        }
+                    }
+
+                    _ = shutdown_rx.recv() => {
+                        log::info!(logger, "DeqsServer shutdown requested");
+                        break
+                    }
+
+                }
+            }
+
+            // This will cause the receiver to become ready (and return None when recv() is
+            // called)
+            drop(shutdown_ack_tx);
+        });
+
+        Ok(Self {
+            shutdown_tx,
+            shutdown_ack_rx,
+            grpc_server,
+        })
+    }
+
+    pub async fn shutdown(&mut self) {
+        if self.shutdown_tx.send(()).is_err() {
+            // Shutdown already requested
+            return;
+        }
+
+        // Wait for the event loop to drop the ack sender.
+        let _ = self.shutdown_ack_rx.recv().await;
+    }
+
+    pub fn grpc_listen_uri(&self) -> Option<DeqsClientUri> {
+        self.grpc_server.actual_listen_uri()
+    }
+}

--- a/server/src/grpc_server.rs
+++ b/server/src/grpc_server.rs
@@ -11,7 +11,7 @@ use postage::broadcast::Sender;
 use std::sync::Arc;
 
 /// DEQS server
-pub struct Server<OB: QuoteBook> {
+pub struct GrpcServer<OB: QuoteBook> {
     /// Message bus sender.
     msg_bus_tx: Sender<Msg>,
 
@@ -28,7 +28,7 @@ pub struct Server<OB: QuoteBook> {
     server: Option<grpcio::Server>,
 }
 
-impl<OB: QuoteBook> Server<OB> {
+impl<OB: QuoteBook> GrpcServer<OB> {
     pub fn new(
         msg_bus_tx: Sender<Msg>,
         quote_book: OB,
@@ -48,7 +48,7 @@ impl<OB: QuoteBook> Server<OB> {
     pub fn start(&mut self) -> Result<(), Error> {
         let ret = self.start_helper();
         if let Err(ref err) = ret {
-            log::error!(self.logger, "Server failed to start: {}", err);
+            log::error!(self.logger, "GrpcServer failed to start: {}", err);
             self.stop();
         }
         ret
@@ -112,7 +112,7 @@ impl<OB: QuoteBook> Server<OB> {
     }
 }
 
-impl<OB: QuoteBook> Drop for Server<OB> {
+impl<OB: QuoteBook> Drop for GrpcServer<OB> {
     fn drop(&mut self) {
         self.stop();
     }

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -3,6 +3,7 @@
 mod client_service;
 mod config;
 mod error;
+mod deqs_server;
 mod grpc_server;
 mod metrics;
 mod msg;
@@ -12,6 +13,7 @@ pub use client_service::ClientService;
 pub use config::ServerConfig;
 pub use error::Error;
 pub use grpc_server::GrpcServer;
+pub use deqs_server::DeqsServer;
 pub use metrics::SVC_COUNTERS;
 pub use msg::Msg;
 pub use p2p::P2P;

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -3,17 +3,17 @@
 mod client_service;
 mod config;
 mod error;
-mod deqs_server;
 mod grpc_server;
 mod metrics;
 mod msg;
 mod p2p;
+mod server;
 
 pub use client_service::ClientService;
 pub use config::ServerConfig;
 pub use error::Error;
 pub use grpc_server::GrpcServer;
-pub use deqs_server::DeqsServer;
 pub use metrics::SVC_COUNTERS;
 pub use msg::Msg;
 pub use p2p::P2P;
+pub use server::Server;

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -3,15 +3,15 @@
 mod client_service;
 mod config;
 mod error;
+mod grpc_server;
 mod metrics;
 mod msg;
 mod p2p;
-mod server;
 
 pub use client_service::ClientService;
 pub use config::ServerConfig;
 pub use error::Error;
+pub use grpc_server::GrpcServer;
 pub use metrics::SVC_COUNTERS;
 pub use msg::Msg;
 pub use p2p::P2P;
-pub use server::Server;

--- a/server/src/p2p/mod.rs
+++ b/server/src/p2p/mod.rs
@@ -117,6 +117,11 @@ impl<QB: QuoteBook> P2P<QB> {
         ))
     }
 
+    //// Get list of listening addresses.
+    pub async fn listen_addrs(&mut self) -> Result<Vec<Multiaddr>, Error> {
+        Ok(self.client.listen_addrs().await?)
+    }
+
     /// Broadcast to other peers that a new quote has been added to the quote
     /// book.
     pub async fn broadcast_sci_quote_added(&mut self, quote: Quote) -> Result<(), Error> {

--- a/server/src/server.rs
+++ b/server/src/server.rs
@@ -20,6 +20,9 @@ pub struct Server<QB: QuoteBook> {
 
     /// Must hold a reference to the grpc server, otherwise it will be dropped.
     grpc_server: GrpcServer<QB>,
+
+    /// Addresses the peer to peer network is listening on.
+    p2p_listen_addrs: Vec<Multiaddr>,
 }
 
 impl<QB: QuoteBook> Server<QB> {
@@ -46,6 +49,9 @@ impl<QB: QuoteBook> Server<QB> {
             logger.clone(),
         )
         .await?;
+
+        // Get p2p listening addresses
+        let p2p_listen_addrs = p2p.listen_addrs().await?;
 
         // Start GRPC server
         let mut grpc_server =
@@ -108,6 +114,7 @@ impl<QB: QuoteBook> Server<QB> {
             shutdown_tx,
             shutdown_ack_rx,
             grpc_server,
+            p2p_listen_addrs,
         })
     }
 
@@ -123,5 +130,9 @@ impl<QB: QuoteBook> Server<QB> {
 
     pub fn grpc_listen_uri(&self) -> Option<DeqsClientUri> {
         self.grpc_server.actual_listen_uri()
+    }
+
+    pub fn p2p_listen_addrs(&self) -> Vec<Multiaddr> {
+        self.p2p_listen_addrs.clone()
     }
 }

--- a/server/src/server.rs
+++ b/server/src/server.rs
@@ -11,7 +11,7 @@ use tokio::{select, sync::mpsc};
 /// Maximum number of messages that can be queued in the message bus.
 const MSG_BUS_QUEUE_SIZE: usize = 1000;
 
-pub struct DeqsServer<QB: QuoteBook> {
+pub struct Server<QB: QuoteBook> {
     /// Shutdown sender, used to signal the event loop to shutdown.
     shutdown_tx: mpsc::UnboundedSender<()>,
 
@@ -22,7 +22,7 @@ pub struct DeqsServer<QB: QuoteBook> {
     grpc_server: GrpcServer<QB>,
 }
 
-impl<QB: QuoteBook> DeqsServer<QB> {
+impl<QB: QuoteBook> Server<QB> {
     pub async fn start(
         quote_book: QB,
         grpc_listen_address: DeqsClientUri,
@@ -56,7 +56,7 @@ impl<QB: QuoteBook> DeqsServer<QB> {
 
         // Event loop
         tokio::spawn(async move {
-            log::info!(logger, "DeqsServer event loop started");
+            log::info!(logger, "Server event loop started");
 
             loop {
                 select! {
@@ -92,7 +92,7 @@ impl<QB: QuoteBook> DeqsServer<QB> {
                     }
 
                     _ = shutdown_rx.recv() => {
-                        log::info!(logger, "DeqsServer shutdown requested");
+                        log::info!(logger, "Server shutdown requested");
                         break
                     }
 

--- a/server/tests/e2e.rs
+++ b/server/tests/e2e.rs
@@ -35,64 +35,69 @@ fn create_and_initialize_test_ledger() -> LedgerDB {
     ledger
 }
 
+// Helper to start a deqs server.
+type TestQuoteBook = SynchronizedQuoteBook<InMemoryQuoteBook, LedgerDB>;
+type TestServer = Server<TestQuoteBook>;
+async fn start_deqs_server(
+    ledger_db: &LedgerDB,
+    p2p_bootstrap_from: &[&TestServer],
+    logger: &Logger,
+) -> (TestServer, TestQuoteBook, DeqsClientApiClient) {
+    let internal_quote_book = InMemoryQuoteBook::default();
+    let synchronized_quote_book =
+        SynchronizedQuoteBook::new(internal_quote_book, ledger_db.clone());
+
+    let deqs_server = Server::start(
+        synchronized_quote_book.clone(),
+        DeqsClientUri::from_str("insecure-deqs://127.0.0.1:0/").unwrap(),
+        p2p_bootstrap_from
+            .into_iter()
+            .map(|server| server.p2p_listen_addrs())
+            .flatten()
+            .collect(),
+        None,
+        None,
+        None,
+        logger.clone(),
+    )
+    .await
+    .unwrap();
+
+    let client_env = Arc::new(EnvBuilder::new().build());
+    let ch = ChannelBuilder::default_channel_builder(client_env)
+        .connect_to_uri(&deqs_server.grpc_listen_uri().unwrap(), &logger);
+    let client_api = DeqsClientApiClient::new(ch);
+
+    (deqs_server, synchronized_quote_book, client_api)
+}
+
+/// Test that two nodes propagate quotes being added and removed to eachother.
 #[async_test_with_logger]
-async fn two_nodes_e2e(logger: Logger) {
+async fn two_nodes_e2e_quote_propagation(logger: Logger) {
     let mut rng: StdRng = SeedableRng::from_seed([1u8; 32]);
     let ledger_db = create_and_initialize_test_ledger();
 
     // Start two DEQS servers
-    let internal_quote_book1 = InMemoryQuoteBook::default();
-    let synchronized_quote_book1 =
-        SynchronizedQuoteBook::new(internal_quote_book1, ledger_db.clone());
-    let deqs_server1 = Server::start(
-        synchronized_quote_book1.clone(),
-        DeqsClientUri::from_str("insecure-deqs://127.0.0.1:0/").unwrap(),
-        vec![],
-        None,
-        None,
-        None,
-        logger.clone(),
-    )
-    .await
-    .unwrap();
+    let (deqs_server1, quote_book1, client1) = start_deqs_server(&ledger_db, &[], &logger).await;
 
-    let internal_quote_book2 = InMemoryQuoteBook::default();
-    let synchronized_quote_book2 =
-        SynchronizedQuoteBook::new(internal_quote_book2, ledger_db.clone());
-    let deqs_server2 = Server::start(
-        synchronized_quote_book2.clone(),
-        DeqsClientUri::from_str("insecure-deqs://127.0.0.1:0/").unwrap(),
-        deqs_server1.p2p_listen_addrs(),
-        None,
-        None,
-        None,
-        logger.clone(),
-    )
-    .await
-    .unwrap();
+    let (_deqs_server2, quote_book2, client2) =
+        start_deqs_server(&ledger_db, &[&deqs_server1], &logger).await;
 
     // Submit an SCI to the first server
     let sci =
         deqs_mc_test_utils::create_sci(TokenId::from(1), TokenId::from(2), 10000, 20000, &mut rng);
 
-    let client1_env = Arc::new(EnvBuilder::new().build());
-    let ch = ChannelBuilder::default_channel_builder(client1_env)
-        .connect_to_uri(&deqs_server1.grpc_listen_uri().unwrap(), &logger);
-    let client1_api = DeqsClientApiClient::new(ch);
-
     let req = SubmitQuotesRequest {
         quotes: vec![(&sci).into()].into(),
         ..Default::default()
     };
-    let resp = client1_api
-        .submit_quotes(&req)
-        .expect("submit quote failed");
+    let resp = client1.submit_quotes(&req).expect("submit quote failed");
     let quote_id = QuoteId::try_from(resp.get_quotes()[0].get_id()).unwrap();
 
     // After a few moments the second server should have the SCI in its quote book
     let retry_strategy = FixedInterval::new(Duration::from_secs(1)).take(10); // limit to 10 retries
     let quote = Retry::spawn(retry_strategy, || async {
-        let quote = synchronized_quote_book2.get_quote_by_id(&quote_id);
+        let quote = quote_book2.get_quote_by_id(&quote_id);
         match quote {
             Ok(Some(quote)) => Ok(quote),
             Ok(None) => Err("not yet".to_string()),
@@ -108,26 +113,18 @@ async fn two_nodes_e2e(logger: Logger) {
     // the first server. First sanity test that SCI is in fact in the quote book
     // of the first server.
     assert_eq!(
-        synchronized_quote_book1
-            .get_quote_by_id(&quote_id)
-            .unwrap()
-            .unwrap(),
+        quote_book1.get_quote_by_id(&quote_id).unwrap().unwrap(),
         quote
     );
 
-    let client2_env = Arc::new(EnvBuilder::new().build());
-    let ch = ChannelBuilder::default_channel_builder(client2_env)
-        .connect_to_uri(&deqs_server2.grpc_listen_uri().unwrap(), &logger);
-    let client2_api = DeqsClientApiClient::new(ch);
-
     let mut req = RemoveQuoteRequest::default();
     req.set_quote_id((&quote_id).into());
-    let _resp = client2_api.remove_quote(&req).expect("remove quote failed");
+    let _resp = client2.remove_quote(&req).expect("remove quote failed");
 
     // Quote should eventually be removed from the first server
     let retry_strategy = FixedInterval::new(Duration::from_secs(1)).take(10); // limit to 10 retries
     Retry::spawn(retry_strategy, || async {
-        let quote = synchronized_quote_book1.get_quote_by_id(&quote_id);
+        let quote = quote_book1.get_quote_by_id(&quote_id);
         match quote {
             Ok(Some(_quote)) => Err("not yet".to_string()),
             Ok(None) => Ok(()),

--- a/server/tests/e2e.rs
+++ b/server/tests/e2e.rs
@@ -1,27 +1,30 @@
 // Copyright (c) 2023 MobileCoin Inc.
 
-use std::str::FromStr;
+use std::{str::FromStr, sync::Arc, time::Duration};
 
-use deqs_api::DeqsClientUri;
-use deqs_quote_book::{InMemoryQuoteBook, SynchronizedQuoteBook};
+use deqs_api::{deqs::SubmitQuotesRequest, deqs_grpc::DeqsClientApiClient, DeqsClientUri};
+use deqs_quote_book::{InMemoryQuoteBook, QuoteBook, QuoteId, SynchronizedQuoteBook};
 use deqs_server::Server;
+use grpcio::{ChannelBuilder, EnvBuilder};
 use mc_account_keys::AccountKey;
 use mc_common::logger::{async_test_with_logger, Logger};
 use mc_ledger_db::{
     test_utils::{create_ledger, initialize_ledger},
     LedgerDB,
 };
-use mc_transaction_types::BlockVersion;
+use mc_transaction_types::{BlockVersion, TokenId};
+use mc_util_grpc::ConnectionUriGrpcioChannel;
 use rand::{rngs::StdRng, SeedableRng};
+use tokio_retry::{strategy::FixedInterval, Retry};
 
 fn create_and_initialize_test_ledger() -> LedgerDB {
-    //Create a ledger_db
+    // Create a ledger_db
     let mut rng: StdRng = SeedableRng::from_seed([1u8; 32]);
     let block_version = BlockVersion::MAX;
     let sender = AccountKey::random(&mut rng);
     let mut ledger = create_ledger();
 
-    //Initialize that db
+    // Initialize that db
     let n_blocks = 3;
     initialize_ledger(block_version, &mut ledger, n_blocks, &sender, &mut rng);
 
@@ -30,12 +33,15 @@ fn create_and_initialize_test_ledger() -> LedgerDB {
 
 #[async_test_with_logger]
 async fn e2e(logger: Logger) {
+    let mut rng: StdRng = SeedableRng::from_seed([1u8; 32]);
     let ledger_db = create_and_initialize_test_ledger();
-    let internal_quote_book = InMemoryQuoteBook::default();
-    let synchronized_quote_book = SynchronizedQuoteBook::new(internal_quote_book, ledger_db);
 
-    let deqs_server = Server::start(
-        synchronized_quote_book,
+    // Start two DEQS servers
+    let internal_quote_book1 = InMemoryQuoteBook::default();
+    let synchronized_quote_book1 =
+        SynchronizedQuoteBook::new(internal_quote_book1, ledger_db.clone());
+    let deqs_server1 = Server::start(
+        synchronized_quote_book1,
         DeqsClientUri::from_str("insecure-deqs://127.0.0.1:0/").unwrap(),
         vec![],
         None,
@@ -46,9 +52,55 @@ async fn e2e(logger: Logger) {
     .await
     .unwrap();
 
-    panic!(
-        "{:?} {:?}",
-        deqs_server.grpc_listen_uri(),
-        deqs_server.p2p_listen_addrs(),
-    );
+    let internal_quote_book2 = InMemoryQuoteBook::default();
+    let synchronized_quote_book2 =
+        SynchronizedQuoteBook::new(internal_quote_book2, ledger_db.clone());
+    let _deqs_server2 = Server::start(
+        synchronized_quote_book2.clone(),
+        DeqsClientUri::from_str("insecure-deqs://127.0.0.1:0/").unwrap(),
+        deqs_server1.p2p_listen_addrs(),
+        None,
+        None,
+        None,
+        logger.clone(),
+    )
+    .await
+    .unwrap();
+
+    // Submit an SCI to the first server
+    let sci =
+        deqs_mc_test_utils::create_sci(TokenId::from(1), TokenId::from(2), 10000, 20000, &mut rng);
+
+    let client_env = Arc::new(EnvBuilder::new().build());
+    let ch = ChannelBuilder::default_channel_builder(client_env)
+        .connect_to_uri(&deqs_server1.grpc_listen_uri().unwrap(), &logger);
+    let client_api = DeqsClientApiClient::new(ch);
+
+    let req = SubmitQuotesRequest {
+        quotes: vec![(&sci).into()].into(),
+        ..Default::default()
+    };
+    let resp = client_api.submit_quotes(&req).expect("submit quote failed");
+    let quote_id = QuoteId::try_from(resp.get_quotes()[0].get_id()).unwrap();
+
+    // After a few moments the second server should have the SCI in its quote book
+    let retry_strategy = FixedInterval::new(Duration::from_secs(1)).take(10); // limit to 10 retries
+    let quote = Retry::spawn(retry_strategy, || async {
+        let quote = synchronized_quote_book2.get_quote_by_id(&quote_id);
+        match quote {
+            Ok(Some(quote)) => {
+                return Result::<_, String>::Ok(quote);
+            }
+            Ok(None) => {
+                return Result::<_, String>::Err("not yet".to_string());
+            }
+            Err(e) => {
+                return Result::<_, String>::Err(format!("error: {:?}", e));
+            }
+        }
+    })
+    .await
+    .unwrap();
+
+    assert_eq!(quote.sci(), &sci);
 }

--- a/server/tests/e2e.rs
+++ b/server/tests/e2e.rs
@@ -88,15 +88,9 @@ async fn e2e(logger: Logger) {
     let quote = Retry::spawn(retry_strategy, || async {
         let quote = synchronized_quote_book2.get_quote_by_id(&quote_id);
         match quote {
-            Ok(Some(quote)) => {
-                return Result::<_, String>::Ok(quote);
-            }
-            Ok(None) => {
-                return Result::<_, String>::Err("not yet".to_string());
-            }
-            Err(e) => {
-                return Result::<_, String>::Err(format!("error: {:?}", e));
-            }
+            Ok(Some(quote)) => Ok(quote),
+            Ok(None) => Err("not yet".to_string()),
+            Err(e) => Err(format!("error: {:?}", e)),
         }
     })
     .await

--- a/server/tests/e2e.rs
+++ b/server/tests/e2e.rs
@@ -34,7 +34,7 @@ async fn e2e(logger: Logger) {
     let internal_quote_book = InMemoryQuoteBook::default();
     let synchronized_quote_book = SynchronizedQuoteBook::new(internal_quote_book, ledger_db);
 
-    let _deqs_server = Server::start(
+    let deqs_server = Server::start(
         synchronized_quote_book,
         DeqsClientUri::from_str("insecure-deqs://127.0.0.1:0/").unwrap(),
         vec![],
@@ -46,8 +46,9 @@ async fn e2e(logger: Logger) {
     .await
     .unwrap();
 
-    tokio::time::sleep(std::time::Duration::from_secs(5)).await;
-
-    drop(_deqs_server);
-    tokio::time::sleep(std::time::Duration::from_secs(5)).await;
+    panic!(
+        "{:?} {:?}",
+        deqs_server.grpc_listen_uri(),
+        deqs_server.p2p_listen_addrs(),
+    );
 }

--- a/server/tests/e2e.rs
+++ b/server/tests/e2e.rs
@@ -1,0 +1,53 @@
+// Copyright (c) 2023 MobileCoin Inc.
+
+use std::str::FromStr;
+
+use deqs_api::DeqsClientUri;
+use deqs_quote_book::{InMemoryQuoteBook, SynchronizedQuoteBook};
+use deqs_server::Server;
+use mc_account_keys::AccountKey;
+use mc_common::logger::{async_test_with_logger, Logger};
+use mc_ledger_db::{
+    test_utils::{create_ledger, initialize_ledger},
+    LedgerDB,
+};
+use mc_transaction_types::BlockVersion;
+use rand::{rngs::StdRng, SeedableRng};
+
+fn create_and_initialize_test_ledger() -> LedgerDB {
+    //Create a ledger_db
+    let mut rng: StdRng = SeedableRng::from_seed([1u8; 32]);
+    let block_version = BlockVersion::MAX;
+    let sender = AccountKey::random(&mut rng);
+    let mut ledger = create_ledger();
+
+    //Initialize that db
+    let n_blocks = 3;
+    initialize_ledger(block_version, &mut ledger, n_blocks, &sender, &mut rng);
+
+    ledger
+}
+
+#[async_test_with_logger]
+async fn e2e(logger: Logger) {
+    let ledger_db = create_and_initialize_test_ledger();
+    let internal_quote_book = InMemoryQuoteBook::default();
+    let synchronized_quote_book = SynchronizedQuoteBook::new(internal_quote_book, ledger_db);
+
+    let _deqs_server = Server::start(
+        synchronized_quote_book,
+        DeqsClientUri::from_str("insecure-deqs://127.0.0.1:0/").unwrap(),
+        vec![],
+        None,
+        None,
+        None,
+        logger.clone(),
+    )
+    .await
+    .unwrap();
+
+    tokio::time::sleep(std::time::Duration::from_secs(5)).await;
+
+    drop(_deqs_server);
+    tokio::time::sleep(std::time::Duration::from_secs(5)).await;
+}

--- a/server/tests/e2e.rs
+++ b/server/tests/e2e.rs
@@ -2,7 +2,11 @@
 
 use std::{str::FromStr, sync::Arc, time::Duration};
 
-use deqs_api::{deqs::SubmitQuotesRequest, deqs_grpc::DeqsClientApiClient, DeqsClientUri};
+use deqs_api::{
+    deqs::{RemoveQuoteRequest, SubmitQuotesRequest},
+    deqs_grpc::DeqsClientApiClient,
+    DeqsClientUri,
+};
 use deqs_quote_book::{InMemoryQuoteBook, QuoteBook, QuoteId, SynchronizedQuoteBook};
 use deqs_server::Server;
 use grpcio::{ChannelBuilder, EnvBuilder};
@@ -32,7 +36,7 @@ fn create_and_initialize_test_ledger() -> LedgerDB {
 }
 
 #[async_test_with_logger]
-async fn e2e(logger: Logger) {
+async fn two_nodes_e2e(logger: Logger) {
     let mut rng: StdRng = SeedableRng::from_seed([1u8; 32]);
     let ledger_db = create_and_initialize_test_ledger();
 
@@ -41,7 +45,7 @@ async fn e2e(logger: Logger) {
     let synchronized_quote_book1 =
         SynchronizedQuoteBook::new(internal_quote_book1, ledger_db.clone());
     let deqs_server1 = Server::start(
-        synchronized_quote_book1,
+        synchronized_quote_book1.clone(),
         DeqsClientUri::from_str("insecure-deqs://127.0.0.1:0/").unwrap(),
         vec![],
         None,
@@ -55,7 +59,7 @@ async fn e2e(logger: Logger) {
     let internal_quote_book2 = InMemoryQuoteBook::default();
     let synchronized_quote_book2 =
         SynchronizedQuoteBook::new(internal_quote_book2, ledger_db.clone());
-    let _deqs_server2 = Server::start(
+    let deqs_server2 = Server::start(
         synchronized_quote_book2.clone(),
         DeqsClientUri::from_str("insecure-deqs://127.0.0.1:0/").unwrap(),
         deqs_server1.p2p_listen_addrs(),
@@ -71,16 +75,18 @@ async fn e2e(logger: Logger) {
     let sci =
         deqs_mc_test_utils::create_sci(TokenId::from(1), TokenId::from(2), 10000, 20000, &mut rng);
 
-    let client_env = Arc::new(EnvBuilder::new().build());
-    let ch = ChannelBuilder::default_channel_builder(client_env)
+    let client1_env = Arc::new(EnvBuilder::new().build());
+    let ch = ChannelBuilder::default_channel_builder(client1_env)
         .connect_to_uri(&deqs_server1.grpc_listen_uri().unwrap(), &logger);
-    let client_api = DeqsClientApiClient::new(ch);
+    let client1_api = DeqsClientApiClient::new(ch);
 
     let req = SubmitQuotesRequest {
         quotes: vec![(&sci).into()].into(),
         ..Default::default()
     };
-    let resp = client_api.submit_quotes(&req).expect("submit quote failed");
+    let resp = client1_api
+        .submit_quotes(&req)
+        .expect("submit quote failed");
     let quote_id = QuoteId::try_from(resp.get_quotes()[0].get_id()).unwrap();
 
     // After a few moments the second server should have the SCI in its quote book
@@ -97,4 +103,37 @@ async fn e2e(logger: Logger) {
     .unwrap();
 
     assert_eq!(quote.sci(), &sci);
+
+    // Request the second server to remove the SCI, the change should propagate to
+    // the first server. First sanity test that SCI is in fact in the quote book
+    // of the first server.
+    assert_eq!(
+        synchronized_quote_book1
+            .get_quote_by_id(&quote_id)
+            .unwrap()
+            .unwrap(),
+        quote
+    );
+
+    let client2_env = Arc::new(EnvBuilder::new().build());
+    let ch = ChannelBuilder::default_channel_builder(client2_env)
+        .connect_to_uri(&deqs_server2.grpc_listen_uri().unwrap(), &logger);
+    let client2_api = DeqsClientApiClient::new(ch);
+
+    let mut req = RemoveQuoteRequest::default();
+    req.set_quote_id((&quote_id).into());
+    let _resp = client2_api.remove_quote(&req).expect("remove quote failed");
+
+    // Quote should eventually be removed from the first server
+    let retry_strategy = FixedInterval::new(Duration::from_secs(1)).take(10); // limit to 10 retries
+    Retry::spawn(retry_strategy, || async {
+        let quote = synchronized_quote_book1.get_quote_by_id(&quote_id);
+        match quote {
+            Ok(Some(_quote)) => Err("not yet".to_string()),
+            Ok(None) => Ok(()),
+            Err(e) => Err(format!("error: {:?}", e)),
+        }
+    })
+    .await
+    .unwrap();
 }


### PR DESCRIPTION
Most of the work done here was to move stuff from `main.rs` into a new object (`Server`), which takes care of setting up/starting the grpc server/p2p networking/internal msg bus/etc. This can then be used in integration tests, and a simple one is provided.

Edit: added some more tests