### PR TITLE
remove the RemoveQuote API, and the remove quote p2p messages

### DIFF
--- a/api/proto/deqs.proto
+++ b/api/proto/deqs.proto
@@ -17,9 +17,6 @@ service DeqsClientAPI {
     /// This is called to get the existing quotes
     rpc GetQuotes(GetQuotesRequest) returns (GetQuotesResponse) {}
 
-    /// Remove an quote from the quote book
-    rpc RemoveQuote(RemoveQuoteRequest) returns (RemoveQuoteResponse) {}
-
     /// Subscribe for live updates to the quote book
     rpc LiveUpdates(LiveUpdatesRequest) returns (stream LiveUpdate);
 }
@@ -48,7 +45,8 @@ enum QuoteStatusCode {
     INVALID_SCI = 1;
     UNSUPPORTED_SCI = 2;
     QUOTE_ALREADY_EXISTS = 3;
-    OTHER = 4;
+    QUOTE_IS_STALE = 4;
+    OTHER = 5;
 }
 
 message GetQuotesRequest {
@@ -65,14 +63,6 @@ message GetQuotesRequest {
 
 message GetQuotesResponse {
     repeated Quote quotes = 1;
-}
-
-message RemoveQuoteRequest {
-    QuoteId quote_id = 1;
-}
-
-message RemoveQuoteResponse {
-    Quote quote = 1;
 }
 
 message LiveUpdatesRequest {

--- a/api/src/convert/quote_book_error.rs
+++ b/api/src/convert/quote_book_error.rs
@@ -9,6 +9,7 @@ impl From<&Error> for api::QuoteStatusCode {
             Error::Sci(_) => Self::INVALID_SCI,
             Error::UnsupportedSci(_) => Self::UNSUPPORTED_SCI,
             Error::QuoteAlreadyExists => Self::QUOTE_ALREADY_EXISTS,
+            Error::QuoteIsStale => Self::QUOTE_IS_STALE,
             _ => Self::OTHER,
         }
     }

--- a/server/src/client_service.rs
+++ b/server/src/client_service.rs
@@ -4,14 +4,14 @@ use crate::{Msg, SVC_COUNTERS};
 use deqs_api::{
     deqs::{
         GetQuotesRequest, GetQuotesResponse, LiveUpdate, LiveUpdatesRequest, QuoteStatusCode,
-        RemoveQuoteRequest, RemoveQuoteResponse, SubmitQuotesRequest, SubmitQuotesResponse,
+        SubmitQuotesRequest, SubmitQuotesResponse,
     },
     deqs_grpc::{create_deqs_client_api, DeqsClientApi},
 };
-use deqs_quote_book_api::{Error as QuoteBookError, Pair, QuoteBook, QuoteId};
+use deqs_quote_book_api::{Pair, QuoteBook};
 use futures::{FutureExt, SinkExt};
 use grpcio::{
-    RpcContext, RpcStatus, RpcStatusCode, ServerStreamingSink, Service, UnarySink, WriteFlags,
+    RpcContext, RpcStatus, ServerStreamingSink, Service, UnarySink, WriteFlags,
 };
 use mc_common::logger::{log, scoped_global_logger, Logger};
 use mc_transaction_extra::SignedContingentInput;
@@ -162,40 +162,6 @@ impl<OB: QuoteBook> ClientService<OB> {
         })
     }
 
-    fn remove_quote_impl(
-        &mut self,
-        req: RemoveQuoteRequest,
-        logger: &Logger,
-    ) -> Result<RemoveQuoteResponse, RpcStatus> {
-        let quote_id = QuoteId::try_from(req.get_quote_id())
-            .map_err(|err| rpc_invalid_arg_error("quote_id", err, &self.logger))?;
-
-        match self.quote_book.remove_quote_by_id(&quote_id) {
-            Ok(quote) => {
-                log::info!(self.logger, "Quote {} removed", quote.id());
-
-                let mut resp = RemoveQuoteResponse::default();
-                resp.set_quote((&quote).into());
-
-                if let Err(err) = self.msg_bus_tx.blocking_send(Msg::SciQuoteRemoved(quote)) {
-                    log::error!(
-                        logger,
-                        "Failed to send SCI quote {} removed message to message bus: {:?}",
-                        quote_id,
-                        err
-                    );
-                }
-
-                Ok(resp)
-            }
-            Err(QuoteBookError::QuoteNotFound) => Err(RpcStatus::new(RpcStatusCode::NOT_FOUND)),
-            Err(err) => {
-                log::error!(logger, "Failed to remove quote {}: {:?}", quote_id, err);
-                Err(rpc_internal_error("remove_quote", err, &self.logger))
-            }
-        }
-    }
-
     async fn live_updates_impl(
         req: LiveUpdatesRequest,
         mut responses: ServerStreamingSink<LiveUpdate>,
@@ -265,18 +231,6 @@ impl<OB: QuoteBook> DeqsClientApi for ClientService<OB> {
         })
     }
 
-    fn remove_quote(
-        &mut self,
-        ctx: RpcContext,
-        req: RemoveQuoteRequest,
-        sink: UnarySink<RemoveQuoteResponse>,
-    ) {
-        let _timer = SVC_COUNTERS.req(&ctx);
-        scoped_global_logger(&rpc_logger(&ctx, &self.logger), |logger| {
-            send_result(ctx, sink, self.remove_quote_impl(req, logger), logger)
-        })
-    }
-
     fn live_updates(
         &mut self,
         ctx: RpcContext<'_>,
@@ -302,33 +256,41 @@ impl<OB: QuoteBook> DeqsClientApi for ClientService<OB> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use deqs_api::{deqs_grpc::DeqsClientApiClient, DeqsClientUri};
+    use deqs_api::{deqs_grpc::DeqsClientApiClient, DeqsClientUri, deqs::LiveUpdate};
     use deqs_mc_test_utils::create_sci;
-    use deqs_quote_book_api::Quote;
+    use deqs_quote_book_api::{Quote};
     use deqs_quote_book_in_memory::InMemoryQuoteBook;
+    use deqs_quote_book_synchronized::SynchronizedQuoteBook;
     use futures::{executor::block_on, StreamExt};
     use grpcio::{ChannelBuilder, EnvBuilder, Server, ServerBuilder, ServerCredentials};
+    use mc_account_keys::AccountKey;
     use mc_common::logger::test_with_logger;
-    use mc_transaction_types::TokenId;
+use mc_ledger_db::{
+    test_utils::{add_txos_and_key_images_to_ledger, create_ledger, initialize_ledger},
+    LedgerDB, Ledger,
+};
+    use mc_fog_report_validation_test_utils::MockFogResolver;
+    use mc_transaction_builder::test_utils::get_transaction;
+    use mc_transaction_types::{BlockVersion, TokenId};
     use mc_util_grpc::ConnectionUriGrpcioChannel;
     use postage::broadcast;
     use rand::{rngs::StdRng, SeedableRng};
     use std::{
         str::FromStr,
-        sync::{mpsc::channel, Arc},
+        sync::{mpsc::channel, Arc, Mutex},
         thread,
     };
     use tokio::select;
 
-    fn create_test_client_and_server<OB: QuoteBook>(
-        quote_book: &OB,
+    fn create_test_client_and_server<QB: QuoteBook>(
+        quote_book: &QB,
         logger: &Logger,
-    ) -> (DeqsClientApiClient, Server, Receiver<Msg>) {
+    ) -> (DeqsClientApiClient, Server, Sender<Msg>, Receiver<Msg>) {
         let server_env = Arc::new(EnvBuilder::new().build());
         let (msg_bus_tx, msg_bus_rx) = broadcast::channel::<Msg>(1000);
 
         let client_service =
-            ClientService::new(msg_bus_tx, quote_book.clone(), logger.clone()).into_service();
+            ClientService::new(msg_bus_tx.clone(), quote_book.clone(), logger.clone()).into_service();
         let mut server = ServerBuilder::new(server_env)
             .register_service(client_service)
             .build()
@@ -345,7 +307,53 @@ mod tests {
         );
         let client_api = DeqsClientApiClient::new(ch);
 
-        (client_api, server, msg_bus_rx)
+        (client_api, server, msg_bus_tx, msg_bus_rx)
+    }
+
+    fn create_live_updates_subscriber(
+        client_api: DeqsClientApiClient,
+        logger: Logger,
+    ) -> (std::sync::mpsc::Receiver::<LiveUpdate>, std::thread::JoinHandle::<()>) {
+        let (live_updates_tx, live_updates_rx) = channel();
+
+        let join_handle = thread::spawn(move || {
+            let req = LiveUpdatesRequest::default();
+            let mut stream = client_api
+                .live_updates(&req)
+                .expect("stream quotes failed");
+
+            block_on(async {
+                while let Some(resp) = stream.next().await {
+                    match resp {
+                        Ok(resp) => {
+                            log::debug!(logger, "Got a live update: {:?}", resp);
+                            live_updates_tx.send(resp).expect("send failed");
+                            log::debug!(logger, "Sent live update on");
+                        }
+                        Err(err) => {
+                            log::info!(logger, "Live updates thread exiting: {}", err);
+                            break;
+                        }
+                    }
+                }
+            });
+        });
+        
+        (live_updates_rx, join_handle)
+    }
+
+    fn create_and_initialize_test_ledger() -> LedgerDB {
+        // Create a ledger_db
+        let mut rng: StdRng = SeedableRng::from_seed([1u8; 32]);
+        let block_version = BlockVersion::MAX;
+        let sender = AccountKey::random(&mut rng);
+        let mut ledger = create_ledger();
+
+        // Initialize that db
+        let n_blocks = 3;
+        initialize_ledger(block_version, &mut ledger, n_blocks, &sender, &mut rng);
+
+        ledger
     }
 
     #[test_with_logger]
@@ -356,7 +364,7 @@ mod tests {
         };
         let mut rng: StdRng = SeedableRng::from_seed([1u8; 32]);
         let quote_book = InMemoryQuoteBook::default();
-        let (client_api, _server, _msg_bus_rx) =
+        let (client_api, _server, _msg_bus_tx, _msg_bus_rx) =
             create_test_client_and_server(&quote_book, &logger);
 
         let scis = (0..10)
@@ -404,7 +412,7 @@ mod tests {
         };
         let mut rng: StdRng = SeedableRng::from_seed([1u8; 32]);
         let quote_book = InMemoryQuoteBook::default();
-        let (client_api, _server, _msg_bus_rx) =
+        let (client_api, _server, _msg_bus_tx, _msg_bus_rx) =
             create_test_client_and_server(&quote_book, &logger);
 
         let sci = create_sci(pair.base_token_id, pair.counter_token_id, 10, 20, &mut rng);
@@ -430,7 +438,7 @@ mod tests {
         };
         let mut rng: StdRng = SeedableRng::from_seed([1u8; 32]);
         let quote_book = InMemoryQuoteBook::default();
-        let (client_api, _server, _msg_bus_rx) =
+        let (client_api, _server, _msg_bus_tx, _msg_bus_rx) =
             create_test_client_and_server(&quote_book, &logger);
 
         let sci1 = create_sci(pair.base_token_id, pair.counter_token_id, 10, 20, &mut rng);
@@ -465,7 +473,7 @@ mod tests {
     fn get_quotes_filter_correctly(logger: Logger) {
         let mut rng: StdRng = SeedableRng::from_seed([1u8; 32]);
         let quote_book = InMemoryQuoteBook::default();
-        let (client_api, _server, _msg_bus_rx) =
+        let (client_api, _server, _msg_bus_tx, _msg_bus_rx) =
             create_test_client_and_server(&quote_book, &logger);
 
         let sci1 = create_sci(TokenId::from(1), TokenId::from(2), 10, 20, &mut rng);
@@ -544,15 +552,20 @@ mod tests {
     }
 
     #[test_with_logger]
-    fn remove_quote_works(logger: Logger) {
+    fn streaming_works_without_filtering(logger: Logger) {
         let pair = Pair {
-            base_token_id: TokenId::from(1),
-            counter_token_id: TokenId::from(2),
+            base_token_id: TokenId::from(0),
+            counter_token_id: TokenId::from(1),
         };
         let mut rng: StdRng = SeedableRng::from_seed([1u8; 32]);
         let quote_book = InMemoryQuoteBook::default();
-        let (client_api, _server, _msg_bus_rx) =
+        let (client_api, _server, _msg_bus_tx, _msg_bus_rx) =
             create_test_client_and_server(&quote_book, &logger);
+
+        let (live_updates_rx, _join_handle) = create_live_updates_subscriber(client_api.clone(), logger.clone());
+
+        // Initially, the receiver should be empty.
+        assert!(live_updates_rx.try_recv().is_err());
 
         let sci = create_sci(pair.base_token_id, pair.counter_token_id, 10, 20, &mut rng);
         let req = SubmitQuotesRequest {
@@ -566,64 +579,65 @@ mod tests {
         let quotes = quote_book.get_quotes(&pair, .., 0).unwrap();
         assert_eq!(quotes.len(), 1);
 
-        // Remove it.
-        let quote_id = deqs_api::deqs::QuoteId::from(quotes[0].id());
-        let mut req = RemoveQuoteRequest::default();
-        req.set_quote_id(quote_id);
+        let added_quote = &resp.get_quotes()[0];
 
-        let resp = client_api.remove_quote(&req).expect("remove quote failed");
-        assert_eq!(resp.get_quote(), &(&quotes[0]).into());
-
-        // Try again, should fail.
-        assert!(
-            matches!(client_api.remove_quote(&req), Err(grpcio::Error::RpcFailure(status)) if status.code() == grpcio::RpcStatusCode::NOT_FOUND)
-        );
-
-        // Invalid quote id should fail.
-        let req = RemoveQuoteRequest::default();
-        assert!(
-            matches!(client_api.remove_quote(&req), Err(grpcio::Error::RpcFailure(status)) if status.code() == grpcio::RpcStatusCode::INVALID_ARGUMENT)
-        );
+        // We should now see our quote arrive in the stream.
+        let resp = live_updates_rx.recv().expect("recv failed");
+        assert_eq!(resp.get_quote_added(), added_quote);
     }
 
     #[test_with_logger]
-    fn streaming_works_without_filtering(logger: Logger) {
+    fn streaming_works_with_quotes_expiring(logger: Logger) {
         let pair = Pair {
             base_token_id: TokenId::from(0),
             counter_token_id: TokenId::from(1),
         };
         let mut rng: StdRng = SeedableRng::from_seed([1u8; 32]);
-        let quote_book = InMemoryQuoteBook::default();
-        let (client_api, _server, _msg_bus_rx) =
-            create_test_client_and_server(&quote_book, &logger);
 
-        let (tx, rx) = channel();
+        let mut ledger = create_and_initialize_test_ledger();
+        let starting_blocks = ledger.num_blocks().unwrap();
 
-        let thread_client_api = client_api.clone();
-        let _join_handle = thread::spawn(move || {
-            let req = LiveUpdatesRequest::default();
-            let mut stream = thread_client_api
-                .live_updates(&req)
-                .expect("stream quotes failed");
-
-            block_on(async {
-                while let Some(resp) = stream.next().await {
-                    match resp {
-                        Ok(resp) => {
-                            tx.send(resp).expect("send failed");
-                        }
-                        Err(_) => {
-                            break;
-                        }
-                    }
-                }
-            });
+        // Allow msg_bus_tx to be created later for remove_quote_callback,
+        // by putting Mutex<Option<Sender>> in the captured state of the callback
+        let remove_quote_callback_state = Arc::new(Mutex::new(Option::<Sender<Msg>>::default()));
+        let remove_quote_callback_state2 = remove_quote_callback_state.clone();
+        let logger2 = logger.clone();
+        let remove_quote_callback =
+        Box::new(move |quotes: Vec<Quote>| {
+            log::debug!(logger2, "{} quotes removed", quotes.len());
+            for quote in quotes {
+                remove_quote_callback_state.lock().expect("lock poisoned").as_mut().expect("msg_bus_tx was not installed")
+                    .blocking_send(Msg::SciQuoteRemoved(quote.clone()))
+                    .unwrap_or_else(|_| {
+                        panic!(
+                            "Failed to send SCI quote {} removed message to
+        message bus",
+                            quote.id()
+                        )
+                    });
+            }
         });
 
+        let quote_book = SynchronizedQuoteBook::new(
+            InMemoryQuoteBook::default(),
+            ledger.clone(),
+            remove_quote_callback,
+            logger.clone(),
+        );
+
+        let (client_api, _server, msg_bus_tx, _msg_bus_rx) =
+            create_test_client_and_server(&quote_book, &logger);
+
+        // install the msg_bus_tx in the remove_quote_callback's state
+        *remove_quote_callback_state2.lock().expect("lock poisoned") = Some(msg_bus_tx);
+
+        let (live_updates_rx, _join_handle) = create_live_updates_subscriber(client_api.clone(), logger.clone());
+
         // Initially, the receiver should be empty.
-        assert!(rx.try_recv().is_err());
+        assert!(live_updates_rx.try_recv().is_err());
 
         let sci = create_sci(pair.base_token_id, pair.counter_token_id, 10, 20, &mut rng);
+        let key_image = sci.key_image();
         let req = SubmitQuotesRequest {
             quotes: vec![(&sci).into()].into(),
             ..Default::default()
@@ -632,18 +646,53 @@ mod tests {
         assert_eq!(resp.status_codes, vec![QuoteStatusCode::CREATED]);
         let added_quote = &resp.get_quotes()[0];
 
-        // We should now see our quote arrive in the stream.
-        let resp = rx.recv().expect("recv failed");
+        // We should now see our quote arrive in the live updates stream.
+        let resp = live_updates_rx.recv().expect("recv failed");
         assert_eq!(resp.get_quote_added(), added_quote);
+        // There should not be any more updates right now
+        assert!(live_updates_rx.try_recv().is_err());
 
-        // Remove the quote, we should see a live update.
-        let mut req = RemoveQuoteRequest::default();
-        req.set_quote_id(added_quote.get_id().clone());
+        // Build a Tx and add its outputs, and the sci's key image, to the ledger
+        let block_version = BlockVersion::MAX;
+        let fog_resolver = MockFogResolver::default();
 
-        let _resp = client_api.remove_quote(&req).expect("remove quote failed");
+        let offerer_account = AccountKey::random(&mut rng);
 
-        let resp = rx.recv().expect("recv failed");
+        let tx = get_transaction(
+            block_version,
+            TokenId::from(0),
+            2,
+            2,
+            &offerer_account,
+            &offerer_account,
+            fog_resolver,
+            &mut rng,
+        )
+        .unwrap();
+        add_txos_and_key_images_to_ledger(
+            &mut ledger,
+            BlockVersion::MAX,
+            tx.prefix.outputs,
+            vec![key_image],
+            &mut rng,
+        )
+        .unwrap();
+
+        assert_eq!(ledger.num_blocks().unwrap(), starting_blocks + 1);
+
+        log::debug!(logger, "added a block");
+        // Block until we get a live update showing it is removed
+        let resp = live_updates_rx.recv().expect("recv failed");
+        log::debug!(logger, "live_updates_rx.recv() returned");
         assert_eq!(resp.get_quote_removed(), added_quote.get_id());
+
+        // If we try to add the same quote back, it should be rejected as stale
+        let req = SubmitQuotesRequest {
+            quotes: vec![(&sci).into()].into(),
+            ..Default::default()
+        };
+        let resp = client_api.submit_quotes(&req).expect("submit quote failed");
+        assert_eq!(resp.status_codes, vec![QuoteStatusCode::QUOTE_IS_STALE]);
     }
 
     #[test_with_logger]
@@ -659,7 +708,7 @@ mod tests {
 
         let mut rng: StdRng = SeedableRng::from_seed([1u8; 32]);
         let quote_book = InMemoryQuoteBook::default();
-        let (client_api, _server, _msg_bus_rx) =
+        let (client_api, _server, _msg_bus_tx, _msg_bus_rx) =
             create_test_client_and_server(&quote_book, &logger);
 
         let (tx1, rx1) = channel();

--- a/server/src/client_service.rs
+++ b/server/src/client_service.rs
@@ -590,12 +590,14 @@ mod tests {
         assert!(live_updates_rx.try_recv().is_err());
 
         // Announce over the message bus that a quote has been removed
-        msg_bus_tx.blocking_send(Msg::SciQuoteRemoved(added_quote.try_into().unwrap())).expect("msg_bus reader died");
+        msg_bus_tx
+            .blocking_send(Msg::SciQuoteRemoved(added_quote.try_into().unwrap()))
+            .expect("msg_bus reader died");
 
         // The live update subscription should get an update
         let resp = live_updates_rx.recv().expect("recv failed");
         log::debug!(logger, "live_updates_rx.recv() returned");
-        assert_eq!(resp.get_quote_removed(), added_quote.get_id());        
+        assert_eq!(resp.get_quote_removed(), added_quote.get_id());
     }
 
     #[test_with_logger]
@@ -641,7 +643,6 @@ mod tests {
             .map(|quote| SignedContingentInput::try_from(quote.get_sci()).unwrap())
             .collect::<Vec<_>>();
         assert_eq!(received_scis, vec![sci.clone()]);
-
 
         // Build a Tx and add its outputs, and the sci's key image, to the ledger
         let block_version = BlockVersion::MAX;

--- a/server/src/server.rs
+++ b/server/src/server.rs
@@ -86,10 +86,11 @@ impl<QB: QuoteBook> Server<QB> {
                                 }
                             }
 
-                            Some(Msg::SciQuoteRemoved(quote)) => {
-                                if let Err(err) = p2p.broadcast_sci_quote_removed(*quote.id()).await {
-                                    log::info!(logger, "broadcast_sci_quote_removed failed: {:?}", err)
-                                }
+                            Some(Msg::SciQuoteRemoved(_quote)) => {
+                                // We don't have to broadcast SciQuoteRemoved to peers over p2p, because
+                                // these are removed when the ledger advances, and all the p2p peers will
+                                // see that eventually.
+                                // This message is forwarded to live updates subscribers though.
                             }
 
                             None => {

--- a/server/tests/e2e.rs
+++ b/server/tests/e2e.rs
@@ -1,7 +1,7 @@
 // Copyright (c) 2023 MobileCoin Inc.
 
 use deqs_api::{
-    deqs::{RemoveQuoteRequest, SubmitQuotesRequest},
+    deqs::{SubmitQuotesRequest},
     deqs_grpc::DeqsClientApiClient,
     DeqsClientUri,
 };
@@ -75,31 +75,6 @@ async fn start_deqs_server(
     (deqs_server, synchronized_quote_book, client_api)
 }
 
-async fn start_in_memory_deqs_server(
-    p2p_bootstrap_from: &[&TestServer],
-    initial_scis: &[SignedContingentInput],
-    logger: &Logger,
-) -> (
-    Server<InMemoryQuoteBook>,
-    InMemoryQuoteBook,
-    DeqsClientApiClient,
-) {
-    let (msg_bus_tx, msg_bus_rx) = broadcast::channel::<Msg>(MSG_BUS_QUEUE_SIZE);
-    let internal_quote_book = InMemoryQuoteBook::default();
-
-    let (deqs_server, client_api) = start_deqs_server_for_quotebook(
-        initial_scis,
-        &internal_quote_book,
-        p2p_bootstrap_from,
-        msg_bus_tx,
-        msg_bus_rx,
-        logger,
-    )
-    .await;
-
-    (deqs_server, internal_quote_book, client_api)
-}
-
 async fn start_deqs_server_for_quotebook<Q: QuoteBook>(
     initial_scis: &[SignedContingentInput],
     quote_book: &Q,
@@ -167,10 +142,10 @@ async fn e2e_two_nodes_quote_propagation(logger: Logger) {
     let ledger_db = create_and_initialize_test_ledger();
 
     // Start two DEQS servers
-    let (deqs_server1, quote_book1, client1) =
+    let (deqs_server1, _quote_book1, client1) =
         start_deqs_server(&ledger_db, &[], &[], &logger).await;
 
-    let (_deqs_server2, quote_book2, client2) =
+    let (_deqs_server2, quote_book2, _client2) =
         start_deqs_server(&ledger_db, &[&deqs_server1], &[], &logger).await;
 
     // Submit an SCI to the first server
@@ -198,37 +173,12 @@ async fn e2e_two_nodes_quote_propagation(logger: Logger) {
     .unwrap();
 
     assert_eq!(quote.sci(), &sci);
-
-    // Request the second server to remove the SCI, the change should propagate to
-    // the first server. First sanity test that SCI is in fact in the quote book
-    // of the first server.
-    assert_eq!(
-        quote_book1.get_quote_by_id(&quote_id).unwrap().unwrap(),
-        quote
-    );
-
-    let mut req = RemoveQuoteRequest::default();
-    req.set_quote_id((&quote_id).into());
-    let _resp = client2.remove_quote(&req).expect("remove quote failed");
-
-    // Quote should eventually be removed from the first server
-    let retry_strategy = FixedInterval::new(Duration::from_secs(1)).take(30); // limit to 30 retries
-    Retry::spawn(retry_strategy, || async {
-        let quote = quote_book1.get_quote_by_id(&quote_id);
-        match quote {
-            Ok(Some(_quote)) => Err("not yet".to_string()),
-            Ok(None) => Ok(()),
-            Err(e) => Err(format!("error: {:?}", e)),
-        }
-    })
-    .await
-    .unwrap();
 }
 
-/// Test that two nodes propagate quotes being added and removed to each other
-/// where one does not have a ledger.
+/// Test that two nodes propagate quotes being added, and when the ledger invalidates it,
+/// they both remove it
 #[async_test_with_logger]
-async fn e2e_two_nodes_quote_propagation_to_ledger_free_node(logger: Logger) {
+async fn e2e_two_nodes_quote_propagation_and_removal(logger: Logger) {
     let mut rng: StdRng = SeedableRng::from_seed([1u8; 32]);
     let mut ledger_db = create_and_initialize_test_ledger();
 
@@ -237,7 +187,7 @@ async fn e2e_two_nodes_quote_propagation_to_ledger_free_node(logger: Logger) {
         start_deqs_server(&ledger_db, &[], &[], &logger).await;
 
     let (_deqs_server2, quote_book2, _client2) =
-        start_in_memory_deqs_server(&[&deqs_server1], &[], &logger).await;
+        start_deqs_server(&ledger_db, &[&deqs_server1], &[], &logger).await;
 
     // Submit an SCI to the first server
     let sci =
@@ -299,6 +249,19 @@ async fn e2e_two_nodes_quote_propagation_to_ledger_free_node(logger: Logger) {
     .unwrap();
 
     // Quote should eventually be removed from the first server
+    let retry_strategy = FixedInterval::new(Duration::from_secs(1)).take(30); // limit to 30 retries
+    Retry::spawn(retry_strategy, || async {
+        let quote = quote_book1.get_quote_by_id(&quote_id);
+        match quote {
+            Ok(Some(_quote)) => Err("not yet".to_string()),
+            Ok(None) => Ok(()),
+            Err(e) => Err(format!("error: {:?}", e)),
+        }
+    })
+    .await
+    .unwrap();
+
+    // Quote should eventually be removed from the second server
     let retry_strategy = FixedInterval::new(Duration::from_secs(1)).take(30); // limit to 30 retries
     Retry::spawn(retry_strategy, || async {
         let quote = quote_book2.get_quote_by_id(&quote_id);

--- a/server/tests/e2e.rs
+++ b/server/tests/e2e.rs
@@ -1,10 +1,6 @@
 // Copyright (c) 2023 MobileCoin Inc.
 
-use deqs_api::{
-    deqs::{SubmitQuotesRequest},
-    deqs_grpc::DeqsClientApiClient,
-    DeqsClientUri,
-};
+use deqs_api::{deqs::SubmitQuotesRequest, deqs_grpc::DeqsClientApiClient, DeqsClientUri};
 use deqs_quote_book_api::{Pair, Quote, QuoteBook, QuoteId};
 use deqs_quote_book_in_memory::InMemoryQuoteBook;
 use deqs_quote_book_synchronized::SynchronizedQuoteBook;
@@ -175,8 +171,8 @@ async fn e2e_two_nodes_quote_propagation(logger: Logger) {
     assert_eq!(quote.sci(), &sci);
 }
 
-/// Test that two nodes propagate quotes being added, and when the ledger invalidates it,
-/// they both remove it
+/// Test that two nodes propagate quotes being added, and when the ledger
+/// invalidates it, they both remove it
 #[async_test_with_logger]
 async fn e2e_two_nodes_quote_propagation_and_removal(logger: Logger) {
     let mut rng: StdRng = SeedableRng::from_seed([1u8; 32]);

--- a/test-cli/src/bin/main.rs
+++ b/test-cli/src/bin/main.rs
@@ -7,7 +7,7 @@ use deqs_api::{
     DeqsClientUri,
 };
 use deqs_mc_test_utils::{create_partial_sci, create_sci};
-use deqs_quote_book_api::{Quote};
+use deqs_quote_book_api::Quote;
 use grpcio::{ChannelBuilder, EnvBuilder};
 use mc_common::logger::{log, o};
 use mc_transaction_types::TokenId;

--- a/test-cli/src/bin/main.rs
+++ b/test-cli/src/bin/main.rs
@@ -2,12 +2,12 @@
 
 use clap::{Parser, Subcommand};
 use deqs_api::{
-    deqs::{QuoteStatusCode, RemoveQuoteRequest, SubmitQuotesRequest},
+    deqs::{QuoteStatusCode, SubmitQuotesRequest},
     deqs_grpc::DeqsClientApiClient,
     DeqsClientUri,
 };
 use deqs_mc_test_utils::{create_partial_sci, create_sci};
-use deqs_quote_book_api::{Quote, QuoteId};
+use deqs_quote_book_api::{Quote};
 use grpcio::{ChannelBuilder, EnvBuilder};
 use mc_common::logger::{log, o};
 use mc_transaction_types::TokenId;
@@ -47,20 +47,6 @@ pub enum Command {
         /// Allow partial fills
         #[clap(long)]
         allow_partial_fills: bool,
-    },
-
-    /// Remove an quote.
-    RemoveQuote {
-        /// gRPC URI for client requests.
-        #[clap(long)]
-        deqs_uri: DeqsClientUri,
-
-        /// Quote id.
-        #[clap(
-            long,
-            value_parser = mc_util_parse::parse_hex::<[u8; 32]>
-        )]
-        quote_id: [u8; 32],
     },
 
     /// Generate a p2p keypair and write it to a file
@@ -173,17 +159,6 @@ fn main() {
                     }
                 }
             }
-        }
-
-        Command::RemoveQuote { quote_id, deqs_uri } => {
-            let ch =
-                ChannelBuilder::default_channel_builder(env).connect_to_uri(&deqs_uri, &logger);
-            let client_api = DeqsClientApiClient::new(ch);
-
-            let mut req = RemoveQuoteRequest::default();
-            req.set_quote_id((&QuoteId(quote_id)).into());
-            let resp = client_api.remove_quote(&req).expect("remove quote failed");
-            println!("{:#?}", resp);
         }
 
         Command::GenP2pKeypair { out } => {


### PR DESCRIPTION
We think that the RemoveQuote API is not good to offer to clients, because ultimately, once they have signed a quote, nothing can guarantee that someone else won't match it, and in principle, someone can fork this code, and not remove quotes until they are actually expired. Then they could still be matched, even if we returned a "success" status on a RemoveQuote request.

In order to get users used to the idea that they have to cancel their quotes by sending a mobilecoin transaction, rather than just calling this API, we think we just shouldn't have this API.

Because we don't have this API, we also don't need to have this in the P2P gossip channels either -- all the P2P nodes will see that the quote expired because they are syncing the ledger, and that's their source of truth for whether it has truly expired.

We still send SciQuoteRemoved messages over the LiveUpdates channel. (Maybe we should call it SciQuoteExpired?)

This added some more tests that had to change after this change, and adjusted an e2e test that was testing that RemoveQuote was working.

We also added a new status code for `QUOTE_IS_STALE` to the SubmitQuote API, because otherwise stale quotes got back the non-specific `OTHER` code.