### PR TITLE
update QuoteAlreadyExists error to include the existing quote

### DIFF
--- a/api/proto/deqs.proto
+++ b/api/proto/deqs.proto
@@ -33,7 +33,9 @@ message SubmitQuotesResponse {
     /// String error messages for each case where status code is not CREATED
     repeated string error_messages = 2;
 
-    /// Quotes created. Will contain a valid quote only for entries whose status code is CREATED.
+    /// Quotes - the contents will depend on the status code:
+    /// - CREATED: Contains the newly created quote
+    /// - QUOTE_ALREADY_EXISTS: Contains the existing quote
     repeated Quote quotes = 3;
 }
 

--- a/api/src/convert/quote_book_error.rs
+++ b/api/src/convert/quote_book_error.rs
@@ -8,7 +8,7 @@ impl From<&Error> for api::QuoteStatusCode {
         match src {
             Error::Sci(_) => Self::INVALID_SCI,
             Error::UnsupportedSci(_) => Self::UNSUPPORTED_SCI,
-            Error::QuoteAlreadyExists(_) => Self::QUOTE_ALREADY_EXISTS,
+            Error::QuoteAlreadyExists { .. } => Self::QUOTE_ALREADY_EXISTS,
             Error::QuoteIsStale => Self::QUOTE_IS_STALE,
             _ => Self::OTHER,
         }

--- a/api/src/convert/quote_book_error.rs
+++ b/api/src/convert/quote_book_error.rs
@@ -8,7 +8,7 @@ impl From<&Error> for api::QuoteStatusCode {
         match src {
             Error::Sci(_) => Self::INVALID_SCI,
             Error::UnsupportedSci(_) => Self::UNSUPPORTED_SCI,
-            Error::QuoteAlreadyExists => Self::QUOTE_ALREADY_EXISTS,
+            Error::QuoteAlreadyExists(_) => Self::QUOTE_ALREADY_EXISTS,
             Error::QuoteIsStale => Self::QUOTE_IS_STALE,
             _ => Self::OTHER,
         }

--- a/quote-book/api/src/error.rs
+++ b/quote-book/api/src/error.rs
@@ -16,7 +16,7 @@ pub enum Error {
     UnsupportedSci(String),
 
     /// Quote already exists in book
-    QuoteAlreadyExists(Quote),
+    QuoteAlreadyExists { existing_quote: Quote },
 
     /// Quote not found
     QuoteNotFound,

--- a/quote-book/api/src/error.rs
+++ b/quote-book/api/src/error.rs
@@ -1,5 +1,6 @@
 // Copyright (c) 2023 MobileCoin Inc.
 
+use crate::Quote;
 use displaydoc::Display;
 use mc_transaction_core::RevealedTxOutError;
 use mc_transaction_extra::SignedContingentInputError;
@@ -15,7 +16,7 @@ pub enum Error {
     UnsupportedSci(String),
 
     /// Quote already exists in book
-    QuoteAlreadyExists,
+    QuoteAlreadyExists(Quote),
 
     /// Quote not found
     QuoteNotFound,

--- a/quote-book/in-memory/src/lib.rs
+++ b/quote-book/in-memory/src/lib.rs
@@ -39,11 +39,11 @@ impl QuoteBook for InMemoryQuoteBook {
         // different pricing.
         // This also ensures that we do not encounter a duplicate id, since the id is a
         // hash of the entire SCI including its key image.
-        if quotes
+        if let Some(existing_quote) = quotes
             .iter()
-            .any(|entry| entry.sci().key_image() == quote.sci().key_image())
+            .find(|entry| entry.sci().key_image() == quote.sci().key_image())
         {
-            return Err(QuoteBookError::QuoteAlreadyExists);
+            return Err(QuoteBookError::QuoteAlreadyExists(existing_quote.clone()));
         }
 
         // Add quote. We assert it doesn't fail since we do not expect duplicate quotes

--- a/quote-book/in-memory/src/lib.rs
+++ b/quote-book/in-memory/src/lib.rs
@@ -43,7 +43,9 @@ impl QuoteBook for InMemoryQuoteBook {
             .iter()
             .find(|entry| entry.sci().key_image() == quote.sci().key_image())
         {
-            return Err(QuoteBookError::QuoteAlreadyExists(existing_quote.clone()));
+            return Err(QuoteBookError::QuoteAlreadyExists {
+                existing_quote: existing_quote.clone(),
+            });
         }
 
         // Add quote. We assert it doesn't fail since we do not expect duplicate quotes

--- a/quote-book/sqlite/src/lib.rs
+++ b/quote-book/sqlite/src/lib.rs
@@ -174,8 +174,8 @@ impl<QB: QuoteBook> QuoteBook for SqliteQuoteBook<QB> {
                                 .and_then(|maybe_quote| maybe_quote.ok_or_else(|| QuoteBookError::ImplementationSpecific(format!("Quote with id {} not found in database (but it should've been!)", quote.id()))))
                                 .and_then(|quote| Quote::try_from(&quote))
                                 {
-                            Ok(quote) => {
-                                QuoteBookError::QuoteAlreadyExists(quote).into()
+                            Ok(existing_quote) => {
+                                QuoteBookError::QuoteAlreadyExists { existing_quote }.into()
                             }
                             Err(err) => QuoteBookError::ImplementationSpecific(format!(
                                 "Getting quote by id {} failed, but we expected it to succeed: {}",

--- a/quote-book/sqlite/src/models.rs
+++ b/quote-book/sqlite/src/models.rs
@@ -2,7 +2,7 @@
 
 use crate::{schema, sql_types::VecU64};
 use deqs_quote_book_api::{Error, Pair, QuoteId};
-use diesel::{Insertable, Queryable};
+use diesel::prelude::*;
 use mc_transaction_extra::SignedContingentInput;
 use mc_transaction_types::TokenId;
 use mc_util_serial::{decode, encode};
@@ -62,6 +62,15 @@ impl Quote {
     }
     pub fn timestamp(&self) -> u64 {
         self.timestamp as u64
+    }
+
+    pub fn get_by_id(conn: &mut SqliteConnection, id: &QuoteId) -> Result<Option<Self>, Error> {
+        let id = id.0.to_vec();
+        Ok(schema::quotes::table
+            .filter(schema::quotes::dsl::id.eq(id))
+            .first(conn)
+            .optional()
+            .map_err(crate::error::Error::from)?)
     }
 }
 

--- a/quote-book/test-suite/src/lib.rs
+++ b/quote-book/test-suite/src/lib.rs
@@ -1,5 +1,7 @@
 // Copyright (c) 2023 MobileCoin Inc.
 
+#![feature(assert_matches)]
+
 use deqs_quote_book_api::{Error, Pair, Quote, QuoteBook, QuoteId};
 use mc_account_keys::AccountKey;
 use mc_crypto_ring_signature::Error as RingSignatureError;
@@ -10,7 +12,7 @@ use mc_transaction_extra::{SignedContingentInput, SignedContingentInputError};
 use mc_transaction_types::{Amount, TokenId};
 use rand::{rngs::StdRng, SeedableRng};
 use rand_core::{CryptoRng, RngCore};
-use std::collections::HashSet;
+use std::{assert_matches::assert_matches, collections::HashSet};
 
 /// Default test pair
 pub fn pair() -> Pair {
@@ -218,12 +220,30 @@ pub fn cannot_add_duplicate_sci(quote_book: &impl QuoteBook) {
     let mut rng: StdRng = SeedableRng::from_seed([1u8; 32]);
 
     let sci = create_sci(&pair, 10, 20, &mut rng);
-    quote_book.add_sci(sci.clone(), None).unwrap();
+    let quote1 = quote_book.add_sci(sci.clone(), None).unwrap();
 
-    assert_eq!(
-        quote_book.add_sci(sci, None).unwrap_err(),
-        Error::QuoteAlreadyExists
+    // Trying to add the exact same SCI should fail
+    assert_matches!(
+        quote_book.add_sci(sci.clone(), None).unwrap_err(),
+        Error::QuoteAlreadyExists(quote) if quote == quote1
     );
+
+    // Trying to add a different SCI with the same key image should fail
+    let mut sci2 = sci.clone();
+    sci2.tx_out_global_indices[0] += 1;
+
+    assert_matches!(
+        quote_book.add_sci(sci2.clone(), None).unwrap_err(),
+        Error::QuoteAlreadyExists(quote) if quote == quote1
+    );
+
+    // Test sanity: Quote id should be different but key image should be
+    // identical.
+    assert_eq!(sci.key_image(), sci2.key_image());
+
+    let quote2 = Quote::new(sci2, None).unwrap();
+    assert_ne!(quote1.id(), quote2.id());
+    assert_eq!(quote1.key_image(), quote2.key_image());
 }
 
 /// Test that get_quotes filter correctly.

--- a/quote-book/test-suite/src/lib.rs
+++ b/quote-book/test-suite/src/lib.rs
@@ -225,7 +225,7 @@ pub fn cannot_add_duplicate_sci(quote_book: &impl QuoteBook) {
     // Trying to add the exact same SCI should fail
     assert_matches!(
         quote_book.add_sci(sci.clone(), None).unwrap_err(),
-        Error::QuoteAlreadyExists(quote) if quote == quote1
+        Error::QuoteAlreadyExists { existing_quote } if existing_quote == quote1
     );
 
     // Trying to add a different SCI with the same key image should fail
@@ -234,7 +234,7 @@ pub fn cannot_add_duplicate_sci(quote_book: &impl QuoteBook) {
 
     assert_matches!(
         quote_book.add_sci(sci2.clone(), None).unwrap_err(),
-        Error::QuoteAlreadyExists(quote) if quote == quote1
+        Error::QuoteAlreadyExists { existing_quote } if existing_quote == quote1
     );
 
     // Test sanity: Quote id should be different but key image should be

--- a/server/src/p2p/mod.rs
+++ b/server/src/p2p/mod.rs
@@ -365,7 +365,7 @@ async fn sync_quotes_from_peer(
                                     );
                                     Ok(())
                                 }
-                                Err(err @ QuoteBookError::QuoteAlreadyExists(_)) => {
+                                Err(err @ QuoteBookError::QuoteAlreadyExists{..}) => {
                                     log::debug!(
                                         logger,
                                         "Failed to add quote {} from {:?}: Already exists (this is acceptable)",
@@ -413,7 +413,7 @@ async fn sync_quotes_from_peer(
     {
         match result {
             Ok(_) => num_added_quotes += 1,
-            Err(Error::QuoteBook(QuoteBookError::QuoteAlreadyExists(_))) => {
+            Err(Error::QuoteBook(QuoteBookError::QuoteAlreadyExists { .. })) => {
                 num_duplicate_quotes += 1
             }
             Err(Error::QuoteBook(QuoteBookError::QuoteNotFound)) => num_missing_quotes += 1,

--- a/server/src/p2p/mod.rs
+++ b/server/src/p2p/mod.rs
@@ -365,13 +365,13 @@ async fn sync_quotes_from_peer(
                                     );
                                     Ok(())
                                 }
-                                Err(err @ QuoteBookError::QuoteAlreadyExists) => {
+                                Err(err @ QuoteBookError::QuoteAlreadyExists(_)) => {
                                     log::debug!(
-                            logger,
-                            "Failed to add quote {} from {:?}: Already exists (this is acceptable)",
-                            quote.id(),
-                            peer_id,
-                        );
+                                        logger,
+                                        "Failed to add quote {} from {:?}: Already exists (this is acceptable)",
+                                        quote.id(),
+                                        peer_id,
+                                    );
                                     Err(err.into())
                                 }
                                 Err(err) => {
@@ -413,7 +413,9 @@ async fn sync_quotes_from_peer(
     {
         match result {
             Ok(_) => num_added_quotes += 1,
-            Err(Error::QuoteBook(QuoteBookError::QuoteAlreadyExists)) => num_duplicate_quotes += 1,
+            Err(Error::QuoteBook(QuoteBookError::QuoteAlreadyExists(_))) => {
+                num_duplicate_quotes += 1
+            }
             Err(Error::QuoteBook(QuoteBookError::QuoteNotFound)) => num_missing_quotes += 1,
             Err(err) => {
                 log::warn!(logger, "Failed to sync quote: {}", err);

--- a/server/src/p2p/rpc_error.rs
+++ b/server/src/p2p/rpc_error.rs
@@ -53,7 +53,7 @@ impl From<QuoteBookError> for RpcQuoteBookError {
         match err {
             QuoteBookError::Sci(err) => Self::Sci(err),
             QuoteBookError::UnsupportedSci(err) => Self::UnsupportedSci(err),
-            QuoteBookError::QuoteAlreadyExists => Self::QuoteAlreadyExists,
+            QuoteBookError::QuoteAlreadyExists(_) => Self::QuoteAlreadyExists,
             QuoteBookError::QuoteNotFound => Self::QuoteNotFound,
             QuoteBookError::QuoteIsStale => Self::QuoteIsStale,
             err => Self::Other(err.to_string()),

--- a/server/src/p2p/rpc_error.rs
+++ b/server/src/p2p/rpc_error.rs
@@ -53,7 +53,7 @@ impl From<QuoteBookError> for RpcQuoteBookError {
         match err {
             QuoteBookError::Sci(err) => Self::Sci(err),
             QuoteBookError::UnsupportedSci(err) => Self::UnsupportedSci(err),
-            QuoteBookError::QuoteAlreadyExists(_) => Self::QuoteAlreadyExists,
+            QuoteBookError::QuoteAlreadyExists { .. } => Self::QuoteAlreadyExists,
             QuoteBookError::QuoteNotFound => Self::QuoteNotFound,
             QuoteBookError::QuoteIsStale => Self::QuoteIsStale,
             err => Self::Other(err.to_string()),


### PR DESCRIPTION
I think it's useful to have the GRPC SubmitQuotes API endpoint return
the already-existing quote when the server decides to reject an SCI for
that reason.
This can help clients have a better idea of whats going on.
Specifically, this is useful for the liquidity bot - the bot will be
periodically resubmitting its SCIs (in case the DEQS lost them), and it
would be beneficial for the bot to know if the quote has been rejected
because that exact code is already there, or if for whatever reason
there is some other quote for the same TxOut the bot is trying to submit
with.

The names `QuoteAlreadyExists` / `QUOTE_ALREADY_EXISTS` are confusing,
since what they actually mean is that the SCI being added overlaps with
some other SCI that is already in the book. Right now this overlap is
determined by the key image, and is tracked per tokens pair.
I suggest renaming thess errors to `OverlappingSCIExists` in a followup
PR.
