### PR TITLE
Liquidity bot picks up where it left after a restart (sort of)

### DIFF
--- a/liquidity-bot/src/bin/main.rs
+++ b/liquidity-bot/src/bin/main.rs
@@ -1,7 +1,11 @@
 // Copyright (c) 2023 MobileCoin Inc.
 
 use clap::Parser;
-use deqs_liquidity_bot::{mini_wallet::MiniWallet, Config, LiquidityBot};
+use deqs_liquidity_bot::{
+    mini_wallet::{MiniWallet, WalletEvent},
+    Config, LiquidityBot,
+};
+use itertools::Itertools;
 use mc_common::logger::{log, o};
 use mc_ledger_db::{Ledger, LedgerDB};
 use mc_util_grpc::AdminServer;
@@ -44,7 +48,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // Start our mini wallet scanner thingie.
     let (wallet_tx, mut wallet_rx) = mpsc::unbounded_channel();
-    let _wallet = MiniWallet::new(
+    let wallet = MiniWallet::new(
         &config.wallet_db,
         ledger_db.clone(),
         account_key.clone(),
@@ -65,6 +69,31 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     )]);
     let liquidity_bot =
         LiquidityBot::new(account_key, ledger_db, pairs, &config.deqs, logger.clone());
+
+    // Since the LiquidityBot itself does not maintain state, feed it any unspent
+    // TxOuts we are currently aware of. It will attempt to submit SCIs for all
+    // of them, and if existing ones are already present on the DEQS for the
+    // same TxOuts (identified by their KeyImage), it will use those instead for
+    // future resubmits. It is safe to not include spent tx outs here since the
+    // TxOuts held inside the wallet's state, at the moment they are grabbed,
+    // are guaranteed to be unspent. If they are spent after the state is grabbed,
+    // the wallet will notify the bot of the spend using the wallet_tx/rx channel.
+    let existing_tx_outs = wallet.matched_tx_outs();
+    log::info!(
+        logger,
+        "Feeding {} existing TxOuts to liquidity bot",
+        existing_tx_outs.len()
+    );
+    for (block_index, received_tx_outs) in &existing_tx_outs
+        .into_iter()
+        .group_by(|mtxo| mtxo.block_index)
+    {
+        liquidity_bot.notify_wallet_event(WalletEvent::BlockProcessed {
+            block_index,
+            received_tx_outs: received_tx_outs.collect(),
+            spent_tx_outs: vec![],
+        });
+    }
 
     loop {
         tokio::select! {

--- a/liquidity-bot/src/lib.rs
+++ b/liquidity-bot/src/lib.rs
@@ -921,7 +921,7 @@ mod tests {
             .iter()
             .map(|mtxo| {
                 let ptxo = test_ctx.task.create_pending_tx_out(mtxo.clone()).unwrap();
-                let quote = Quote::new(ptxo.sci.clone(), None).unwrap();
+                let quote = Quote::new(ptxo.sci, None).unwrap();
                 ListedTxOut {
                     matched_tx_out: mtxo.clone(),
                     quote,

--- a/liquidity-bot/src/lib.rs
+++ b/liquidity-bot/src/lib.rs
@@ -4,12 +4,6 @@
 
 // TODO:
 //
-// - The bot loses all state when it dies, and the wallet will not re-feed it
-//   TxOuts (because the wallet does keep track of which block it last scanned).
-//   Even if it did re-feed it, we wouldn't know which ones were already
-//   previously submitted to the DEQS. As such, we will need to persist the
-//   bot's state
-//
 // - It could be nice for the bot to try and figure out if its orders got
 //   fulfilled. It can do that by looking at spent key images in a given
 //   processed block. If it sees a key image for one of its SCIs, it can look

--- a/liquidity-bot/src/lib.rs
+++ b/liquidity-bot/src/lib.rs
@@ -880,6 +880,71 @@ mod tests {
     }
 
     #[async_test_with_logger]
+    async fn update_pending_tx_outs_from_received_tx_outs_ignores_duplicates(logger: Logger) {
+        let mut test_ctx = TestContext::new(&default_pairs(), &logger);
+
+        // Note that while they have the same value, they are different TxOuts so not
+        // considered duplicates.
+        let matched_tx_outs = vec![
+            test_ctx.create_matched_tx_out(Amount::new(100, TokenId::MOB)),
+            test_ctx.create_matched_tx_out(Amount::new(100, TokenId::MOB)),
+        ];
+
+        assert!(test_ctx
+            .task
+            .update_pending_tx_outs_from_received_tx_outs(&matched_tx_outs)
+            .unwrap());
+
+        assert_eq!(test_ctx.task.pending_tx_outs.len(), 2);
+
+        // Trying to add again should return false and nothing should change.
+        let orig_pending_tx_outs = test_ctx.task.pending_tx_outs.clone();
+        assert!(!test_ctx
+            .task
+            .update_pending_tx_outs_from_received_tx_outs(&matched_tx_outs)
+            .unwrap());
+        assert_eq!(orig_pending_tx_outs, test_ctx.task.pending_tx_outs);
+
+        // Adding a new ones should work.
+        let matched_tx_outs = vec![
+            test_ctx.create_matched_tx_out(Amount::new(100, TokenId::MOB)),
+            test_ctx.create_matched_tx_out(Amount::new(100, TokenId::MOB)),
+        ];
+        assert!(test_ctx
+            .task
+            .update_pending_tx_outs_from_received_tx_outs(&matched_tx_outs)
+            .unwrap());
+
+        assert_eq!(test_ctx.task.pending_tx_outs.len(), 4);
+
+        // We also ignore duplicates in the listed_tx_outs list.
+        let matched_tx_outs = vec![
+            test_ctx.create_matched_tx_out(Amount::new(100, TokenId::MOB)),
+            test_ctx.create_matched_tx_out(Amount::new(100, TokenId::MOB)),
+        ];
+
+        test_ctx.task.listed_tx_outs = matched_tx_outs
+            .iter()
+            .map(|mtxo| {
+                let ptxo = test_ctx.task.create_pending_tx_out(mtxo.clone()).unwrap();
+                let quote = Quote::new(ptxo.sci.clone(), None).unwrap();
+                ListedTxOut {
+                    matched_tx_out: mtxo.clone(),
+                    quote,
+                    last_submitted_at: Instant::now(),
+                }
+            })
+            .collect();
+
+        let orig_pending_tx_outs = test_ctx.task.pending_tx_outs.clone();
+        assert!(!test_ctx
+            .task
+            .update_pending_tx_outs_from_received_tx_outs(&matched_tx_outs)
+            .unwrap());
+        assert_eq!(orig_pending_tx_outs, test_ctx.task.pending_tx_outs);
+    }
+
+    #[async_test_with_logger]
     async fn resubmit_listed_tx_outs_behaves_correctly(logger: Logger) {
         let mut test_ctx = TestContext::new(&default_pairs(), &logger);
 

--- a/liquidity-bot/src/mini_wallet/mod.rs
+++ b/liquidity-bot/src/mini_wallet/mod.rs
@@ -121,6 +121,19 @@ impl MiniWallet {
     pub fn next_block_index(&self) -> BlockIndex {
         self.state.lock().unwrap().next_block_index
     }
+
+    pub fn matched_tx_outs(&self) -> Vec<MatchedTxOut> {
+        let mut matched_tx_outs = self
+            .state
+            .lock()
+            .unwrap()
+            .matched_tx_outs
+            .values()
+            .cloned()
+            .collect::<Vec<_>>();
+        matched_tx_outs.sort_by_key(|matched_tx_out| matched_tx_out.block_index);
+        matched_tx_outs
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Right now, if the bot dies and restarts, the wallet state file will contain currently (at the time of start) unspent MatchedTxOuts. Since the bot will only react to newly scanned blocks, it will not attempt to submit SCIs for these pre-existing TxOuts.

This PR fixes that. What is going to happen is that the bot will try to generate new SCIs for all the MatchedTxOuts that exist in the state file during startup, and when it submits them to the DEQS it will either succeed (if the DEQS removed them), learn that they are stale (if the local ledger is behind), or will update it's quote/SCI if a previous listing for the TxOut is already present.