### PR TITLE
minor logging adjustments

### DIFF
--- a/p2p/src/network_event_loop.rs
+++ b/p2p/src/network_event_loop.rs
@@ -302,7 +302,7 @@ impl<REQ: RpcRequest, RESP: RpcResponse> NetworkEventLoop<REQ, RESP> {
                 QueryResult::GetProviders(Ok(ok)) if ok.key == self.peer_discovery_key => {
                     for peer in ok.providers {
                         let addrs = self.swarm.behaviour_mut().kademlia.addresses_of_peer(&peer);
-                        log::info!(
+                        log::debug!(
                             &self.logger,
                             "Peer {:?} provides key {:?} via addresses {:?}",
                             peer,
@@ -312,7 +312,7 @@ impl<REQ: RpcRequest, RESP: RpcResponse> NetworkEventLoop<REQ, RESP> {
                     }
                 }
                 evt => {
-                    log::info!(&self.logger, "Kademlia event: {:?}", evt);
+                    log::debug!(&self.logger, "Kademlia event: {:?}", evt);
                 }
             },
 

--- a/quote-book/api/src/error.rs
+++ b/quote-book/api/src/error.rs
@@ -27,7 +27,7 @@ pub enum Error {
     /// Quote cannot fulfill the desired amount ({0}) of base tokens
     InsufficientBaseTokens(u64),
 
-    /// Quote has an invalid ring
+    /// Quote has an invalid ring: {0}
     InvalidRing(String),
 
     /// Implementation specific error: {0}

--- a/quote-book/synchronized/src/lib.rs
+++ b/quote-book/synchronized/src/lib.rs
@@ -30,6 +30,10 @@ pub struct SynchronizedQuoteBook<Q: QuoteBook, L: Ledger + Clone + Sync + 'stati
     /// Thread management. This is being held purely for the destructor so that
     /// the SyncThread will be dropped after all the Quotebooks using it.
     _thread_manager: Arc<SyncThread>,
+
+    /// Logger
+    #[allow(unused)]
+    logger: Logger,
 }
 
 impl<Q: QuoteBook, L: Ledger + Clone + Sync + 'static> SynchronizedQuoteBook<Q, L> {
@@ -46,6 +50,7 @@ impl<Q: QuoteBook, L: Ledger + Clone + Sync + 'static> SynchronizedQuoteBook<Q, 
         let thread_highest_processed_block_index = highest_processed_block_index.clone();
         let stop_requested = Arc::new(AtomicBool::new(false));
         let thread_stop_requested = stop_requested.clone();
+        let thread_logger = logger.clone();
         let join_handle = Some(
             ThreadBuilder::new()
                 .name("LedgerDbFetcher".to_owned())
@@ -56,7 +61,7 @@ impl<Q: QuoteBook, L: Ledger + Clone + Sync + 'static> SynchronizedQuoteBook<Q, 
                         remove_quote_callback,
                         thread_highest_processed_block_index,
                         thread_stop_requested,
-                        logger,
+                        thread_logger,
                     )
                 })
                 .expect("Could not spawn thread"),
@@ -70,6 +75,7 @@ impl<Q: QuoteBook, L: Ledger + Clone + Sync + 'static> SynchronizedQuoteBook<Q, 
             ledger,
             highest_processed_block_index,
             _thread_manager,
+            logger,
         }
     }
 


### PR DESCRIPTION
These are some edits left over from when i was trying to debug my Invalid Ring error

* reduce some Kademelia logs to debug, these are spamming at about .1 Hz, and it makes it harder to search the logs for errors
* make InvalidRing error actually display the error details when logged
* store a Logger in synchronized quotebook, this is helpful if you need to jump in and log something, I don't think it's bad if it's unused at this revision.